### PR TITLE
feat: add keyboard grab for active RDP sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,25 @@ The initial RDP size comes from the measured `ScrollViewer` viewport (in DIPs) m
 
 The startup window is intentionally large (`1440x900`) with `MinWidth="900"` and `MinHeight="600"` so the first connection gets a usable initial desktop size.
 
-Keyboard handling is scoped to the RDP image but registered on the window's tunnel route with handled events included. This keeps chords such as `Ctrl+Tab` from losing key-up events while still allowing connection text boxes to receive normal typing when focused.
+Keyboard handling is scoped to the RDP image but registered on the window's tunnel route with handled events included. This keeps chords such as `Ctrl+Tab` from losing key-up events while still allowing connection text boxes to receive normal typing when focused. This is the ungrabbed path; see "Keyboard Grab" below for the other one.
+
+## Keyboard Grab
+
+There are two mutually exclusive keyboard input paths and they must never both be live:
+
+- **Ungrabbed (default, all platforms):** Avalonia tunnel handlers → `RdpViewportPresenter.HandleKeyDown/Up` → `RdpKeyboardInputMapper.TryMapKey` (Avalonia `Key` → PC/XT set-1 scancode).
+- **Grabbed (Windows only):** a `WH_KEYBOARD_LL` hook in `Services/WindowsKeyboardGrab.cs` suppresses every key locally (returns `1`) and raises `KeyIntercepted` → `RdpViewportPresenter.HandleGrabbedKey`. Scancodes come straight from `KBDLLHOOKSTRUCT` via `Services/KeyboardGrabScanCodeMapper.cs`, so this path is layout-independent and does not use `RdpKeyboardInputMapper.TryMapKey`.
+
+`RdpViewportPresenter.SetKeyboardGrabActive` switches between them and flushes the outgoing path's held keys, otherwise modifiers stick on the remote host. `ShouldHandleKeyboardEvent` returns `false` while grabbed so the two paths can never double-send.
+
+Rules:
+
+- The hook callback runs on the Avalonia UI thread. Keep it fast, lock-free and log-free — exceeding `LowLevelHooksTimeout` (~300 ms) makes Windows silently drop the hook. `MainWindow.OnWindowActivated` re-arms it.
+- Never leave the hook installed while disengaged; it is global and sees every keystroke on the machine.
+- Interception is scoped to `GetForegroundWindow() == our HWND`, and `MainWindow.OnWindowDeactivated` force-releases the grab. With no release hotkey, that is the user's only escape route.
+- Grab state is transient per session (`RdpSessionViewModel.IsKeyboardGrabbed`), mirrored to `MainWindowViewModel.IsKeyboardGrabActive` for the toolbar. Do not persist it to `connections.json` or `settings.json`.
+- `IKeyboardGrab.IsSupported` is false on Linux (`NullKeyboardGrab`); the toolbar toggle binds `IsEnabled` to it. X11 `XGrabKeyboard` would be a *different* design — it redirects rather than suppresses, so it keeps the Avalonia path as the transport and would need `LWin`/`RWin` added to `RdpKeyboardInputMapper`. Wayland cannot grab at all without `zwp_keyboard_shortcuts_inhibit_manager_v1`.
+- `Ctrl+Alt+Del` is unhookable; `RdpSessionViewModel.SendCtrlAltDel` emits the scancode sequence explicitly.
 
 ## Test Notes
 

--- a/RDPilot.Client.Tests/KeyboardGrabScanCodeMapperTests.cs
+++ b/RDPilot.Client.Tests/KeyboardGrabScanCodeMapperTests.cs
@@ -1,0 +1,77 @@
+using System.Diagnostics.CodeAnalysis;
+using RDPilot.Client.Services;
+using Xunit;
+
+namespace RDPilot.Client.Tests;
+
+[SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "xUnit test names use underscores for readability.")]
+public sealed class KeyboardGrabScanCodeMapperTests
+{
+    private const uint VirtualKeyTab = 0x09;
+    private const uint VirtualKeyLeftWindows = 0x5B;
+    private const uint VirtualKeySnapshot = 0x2C;
+    private const uint VirtualKeyPause = 0x13;
+
+    private const uint FlagExtended = 0x01;
+    private const uint FlagUp = 0x80;
+
+    [Fact]
+    public void TryMapHookEvent_PlainKeyDown_UsesHardwareScanCode()
+    {
+        Assert.True(KeyboardGrabScanCodeMapper.TryMapHookEvent(
+            VirtualKeyTab, 0x0F, 0, out var scancode, out var extended, out var isUp));
+
+        Assert.Equal((ushort)0x0F, scancode);
+        Assert.False(extended);
+        Assert.False(isUp);
+    }
+
+    [Fact]
+    public void TryMapHookEvent_WindowsKeyRelease_IsExtendedAndUp()
+    {
+        Assert.True(KeyboardGrabScanCodeMapper.TryMapHookEvent(
+            VirtualKeyLeftWindows, 0x5B, FlagExtended | FlagUp, out var scancode, out var extended, out var isUp));
+
+        Assert.Equal((ushort)0x5B, scancode);
+        Assert.True(extended);
+        Assert.True(isUp);
+    }
+
+    [Fact]
+    public void TryMapHookEvent_PrintScreen_NormalizesToExtended37()
+    {
+        Assert.True(KeyboardGrabScanCodeMapper.TryMapHookEvent(
+            VirtualKeySnapshot, 0x54, 0, out var scancode, out var extended, out _));
+
+        Assert.Equal((ushort)0x37, scancode);
+        Assert.True(extended);
+    }
+
+    [Fact]
+    public void TryMapHookEvent_Pause_DropsExtendedBecauseExtended1IsUnsupported()
+    {
+        Assert.True(KeyboardGrabScanCodeMapper.TryMapHookEvent(
+            VirtualKeyPause, 0x45, FlagExtended, out var scancode, out var extended, out _));
+
+        Assert.Equal((ushort)0x45, scancode);
+        Assert.False(extended);
+    }
+
+    [Fact]
+    public void TryMapHookEvent_ZeroScanCode_IsRejected()
+    {
+        Assert.False(KeyboardGrabScanCodeMapper.TryMapHookEvent(
+            VirtualKeyTab, 0, 0, out var scancode, out _, out _));
+
+        Assert.Equal((ushort)0, scancode);
+    }
+
+    [Fact]
+    public void TryMapHookEvent_ScanCodeAboveByteRange_IsMasked()
+    {
+        Assert.True(KeyboardGrabScanCodeMapper.TryMapHookEvent(
+            VirtualKeyTab, 0x1F0F, 0, out var scancode, out _, out _));
+
+        Assert.Equal((ushort)0x0F, scancode);
+    }
+}

--- a/RDPilot.Client.Tests/MainWindowKeyboardGrabTests.cs
+++ b/RDPilot.Client.Tests/MainWindowKeyboardGrabTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using RDPilot.Client.Models;
+using RDPilot.Client.Services;
+using RDPilot.Client.ViewModels;
+using RDPilot.Client.Views;
+using Xunit;
+
+namespace RDPilot.Client.Tests;
+
+[SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "xUnit test names use underscores for readability.")]
+public sealed class MainWindowKeyboardGrabTests
+{
+    public MainWindowKeyboardGrabTests()
+    {
+        AvaloniaTestEnvironment.EnsureInitialized();
+    }
+
+    [Fact]
+    public void SessionToolbar_ExposesKeyboardGrabAndCtrlAltDelButtons()
+    {
+        AvaloniaTestEnvironment.RunOnUiThread(() =>
+        {
+            var window = new MainWindow();
+            try
+            {
+                window.Show();
+
+                Assert.NotNull(FindToolbarButton(window, "KeyboardGrabToggleButton"));
+                Assert.NotNull(FindToolbarButton(window, "SendCtrlAltDelButton"));
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    [Fact]
+    public void KeyboardGrabToggleButton_IsDisabledWhenThePlatformHasNoGrab()
+    {
+        AvaloniaTestEnvironment.RunOnUiThread(() =>
+        {
+            var window = new MainWindow();
+            try
+            {
+                var vm = CreateViewModel();
+                window.DataContext = vm;
+                window.Show();
+                var button = FindToolbarButton(window, "KeyboardGrabToggleButton")!;
+
+                Assert.Equal(vm.IsKeyboardGrabSupported, button.IsEnabled);
+                Assert.False(string.IsNullOrWhiteSpace(vm.KeyboardGrabTooltip));
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    [Fact]
+    public void WindowDeactivation_ReleasesTheKeyboardGrab()
+    {
+        AvaloniaTestEnvironment.RunOnUiThread(() =>
+        {
+            var window = new MainWindow();
+            try
+            {
+                var vm = CreateViewModel();
+                window.DataContext = vm;
+                window.Show();
+                var session = new RdpSessionViewModel(CreateConnection(), RdpSessionStatus.Connected);
+                vm.Sessions.Add(session);
+                vm.SelectedSession = session;
+                session.IsKeyboardGrabbed = true;
+                vm.IsKeyboardGrabActive = true;
+
+                RaiseWindowDeactivated(window);
+
+                Assert.False(vm.IsKeyboardGrabActive);
+                Assert.False(session.IsKeyboardGrabbed);
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    [Fact]
+    public void SwitchingTabs_DoesNotCarryTheGrabToTheNewSession()
+    {
+        AvaloniaTestEnvironment.RunOnUiThread(() =>
+        {
+            var window = new MainWindow();
+            try
+            {
+                var vm = CreateViewModel();
+                window.DataContext = vm;
+                window.Show();
+                var first = new RdpSessionViewModel(CreateConnection("Alpha"), RdpSessionStatus.Connected);
+                var second = new RdpSessionViewModel(CreateConnection("Beta"), RdpSessionStatus.Connected);
+                vm.Sessions.Add(first);
+                vm.Sessions.Add(second);
+                vm.SelectedSession = first;
+                first.IsKeyboardGrabbed = true;
+
+                vm.SelectedSession = second;
+
+                Assert.False(vm.IsKeyboardGrabActive);
+                Assert.False(first.IsKeyboardGrabbed);
+                Assert.False(second.IsKeyboardGrabbed);
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    private static MainWindowViewModel CreateViewModel()
+    {
+        return new MainWindowViewModel(new ConnectionStore(new FakeSecretStore()), new NoSessionFactory());
+    }
+
+    private static Button? FindToolbarButton(MainWindow window, string name)
+    {
+        return window.FindControl<Border>("SessionToolbarHost")?.Child?.FindControl<Button>(name);
+    }
+
+    private static SavedConnection CreateConnection(string name = "Grab Window Test")
+    {
+        return new SavedConnection
+        {
+            Name = name,
+            Host = $"{name.ToLowerInvariant().Replace(' ', '-')}.example.local",
+            Username = "user"
+        };
+    }
+
+    private static void RaiseWindowDeactivated(MainWindow window)
+    {
+        var method = typeof(MainWindow).GetMethod(
+            "OnWindowDeactivated",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method.Invoke(window, [window, EventArgs.Empty]);
+    }
+
+    private sealed class NoSessionFactory : IRdpSessionFactory
+    {
+        public RdpSessionViewModel Create(
+            SavedConnection connection,
+            string password,
+            string gatewayPassword,
+            int width,
+            int height,
+            double renderScaling,
+            int colorDepth,
+            bool compression,
+            bool fontSmoothing,
+            bool bitmapCache,
+            bool desktopWallpaper,
+            bool themes,
+            bool menuAnimations,
+            bool fullWindowDrag,
+            RdpConnectionType connectionType,
+            Action<RdpSessionViewModel, string> remoteClipboardTextReceived,
+            Action<RdpSessionViewModel, string[]> remoteClipboardFilesReceived)
+        {
+            throw new NotSupportedException("Sessions are created directly in these tests.");
+        }
+    }
+
+    private sealed class FakeSecretStore : ISecretStore
+    {
+        public string Description => "Fake";
+
+        public Task<string?> GetSecretAsync(string key) => Task.FromResult<string?>(null);
+        public Task SetSecretAsync(string key, string secret) => Task.CompletedTask;
+        public Task DeleteSecretAsync(string key) => Task.CompletedTask;
+    }
+}

--- a/RDPilot.Client.Tests/MainWindowViewModelTests.cs
+++ b/RDPilot.Client.Tests/MainWindowViewModelTests.cs
@@ -64,6 +64,89 @@ public sealed class MainWindowViewModelTests
     }
 
     [Fact]
+    public async Task IsKeyboardGrabActive_MirrorsTheSelectedSessionGrabState()
+    {
+        using var env = new TestConfigHome();
+        var secretStore = new FakeSecretStore();
+        var store = new ConnectionStore(secretStore);
+        var factory = new QueueSessionFactory([new RdpSessionViewModel(CreateConnection("Grabbable"), RdpSessionStatus.Connected)]);
+        var vm = new MainWindowViewModel(store, factory);
+        await vm.LoadConnectionsAsync();
+        await ConnectAsync(vm, CreateConnection("Grabbable"), secretStore);
+
+        Assert.False(vm.IsKeyboardGrabActive);
+
+        vm.SelectedSession!.IsKeyboardGrabbed = true;
+        Assert.True(vm.IsKeyboardGrabActive);
+
+        vm.ReleaseKeyboardGrab();
+        Assert.False(vm.IsKeyboardGrabActive);
+        Assert.False(vm.SelectedSession.IsKeyboardGrabbed);
+    }
+
+    [Fact]
+    public async Task ToggleKeyboardGrab_WithoutPlatformSupport_DoesNothing()
+    {
+        using var env = new TestConfigHome();
+        var secretStore = new FakeSecretStore();
+        var store = new ConnectionStore(secretStore);
+        var factory = new QueueSessionFactory([new RdpSessionViewModel(CreateConnection("Ungrabbable"), RdpSessionStatus.Connected)]);
+        var vm = new MainWindowViewModel(store, factory);
+        await vm.LoadConnectionsAsync();
+        await ConnectAsync(vm, CreateConnection("Ungrabbable"), secretStore);
+        vm.IsKeyboardGrabSupported = false;
+
+        vm.ToggleKeyboardGrabCommand.Execute(null);
+
+        Assert.False(vm.IsKeyboardGrabActive);
+        Assert.False(vm.SelectedSession!.IsKeyboardGrabbed);
+    }
+
+    [Fact]
+    public async Task ToggleKeyboardGrab_WithPlatformSupport_FlipsTheSelectedSession()
+    {
+        using var env = new TestConfigHome();
+        var secretStore = new FakeSecretStore();
+        var store = new ConnectionStore(secretStore);
+        var factory = new QueueSessionFactory([new RdpSessionViewModel(CreateConnection("Toggleable"), RdpSessionStatus.Connected)]);
+        var vm = new MainWindowViewModel(store, factory);
+        await vm.LoadConnectionsAsync();
+        await ConnectAsync(vm, CreateConnection("Toggleable"), secretStore);
+        vm.IsKeyboardGrabSupported = true;
+        MarkSessionNativeHandleLive(vm.SelectedSession!);
+
+        vm.ToggleKeyboardGrabCommand.Execute(null);
+        Assert.True(vm.IsKeyboardGrabActive);
+
+        vm.ToggleKeyboardGrabCommand.Execute(null);
+        Assert.False(vm.IsKeyboardGrabActive);
+    }
+
+    [Fact]
+    public async Task ToggleKeyboardGrab_SessionWithoutLiveHandle_DoesNothing()
+    {
+        using var env = new TestConfigHome();
+        var secretStore = new FakeSecretStore();
+        var store = new ConnectionStore(secretStore);
+        var factory = new QueueSessionFactory([new RdpSessionViewModel(CreateConnection("Not Live"), RdpSessionStatus.Connected)]);
+        var vm = new MainWindowViewModel(store, factory);
+        await vm.LoadConnectionsAsync();
+        await ConnectAsync(vm, CreateConnection("Not Live"), secretStore);
+        vm.IsKeyboardGrabSupported = true;
+
+        vm.ToggleKeyboardGrabCommand.Execute(null);
+
+        Assert.False(vm.IsKeyboardGrabActive);
+    }
+
+    private static void MarkSessionNativeHandleLive(RdpSessionViewModel session)
+    {
+        var field = typeof(RdpSessionViewModel).GetField("_handle", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field.SetValue(session, new IntPtr(0xC0DE));
+    }
+
+    [Fact]
     public async Task CloseSelectedSession_SelectsNeighbor()
     {
         using var env = new TestConfigHome();

--- a/RDPilot.Client.Tests/NullKeyboardGrabTests.cs
+++ b/RDPilot.Client.Tests/NullKeyboardGrabTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using RDPilot.Client.Services;
+using Xunit;
+
+namespace RDPilot.Client.Tests;
+
+[SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "xUnit test names use underscores for readability.")]
+public sealed class NullKeyboardGrabTests
+{
+    [Fact]
+    public void NullKeyboardGrab_ReportsUnsupportedWithAReason()
+    {
+        using var grab = new NullKeyboardGrab();
+
+        Assert.False(grab.IsSupported);
+        Assert.False(string.IsNullOrWhiteSpace(grab.UnsupportedReason));
+    }
+
+    [Fact]
+    public void SetEngaged_OnUnsupportedPlatform_NeverEngages()
+    {
+        using var grab = new NullKeyboardGrab();
+        grab.Attach(new IntPtr(0x1234));
+
+        grab.SetEngaged(true);
+
+        Assert.False(grab.IsEngaged);
+    }
+}

--- a/RDPilot.Client.Tests/RdpSessionViewModelTests.cs
+++ b/RDPilot.Client.Tests/RdpSessionViewModelTests.cs
@@ -423,6 +423,40 @@ public sealed class RdpSessionViewModelTests
     }
 
     [Fact]
+    public void SendCtrlAltDel_ActiveNativeSession_SendsBalancedDownUpSequence()
+    {
+        var session = new RdpSessionViewModel(CreateConnection("Ctrl Alt Del Test"), RdpSessionStatus.Connected);
+        var nativeSession = new FakeNativeSession(new IntPtr(0x789B));
+        AttachNativeSession(session, nativeSession);
+
+        session.SendCtrlAltDel();
+
+        Assert.Equal(
+            [
+                ((ushort)0x0000, (ushort)0x1D),
+                ((ushort)0x0000, (ushort)0x38),
+                ((ushort)0x0100, (ushort)0x53),
+                ((ushort)0x8100, (ushort)0x53),
+                ((ushort)0x8000, (ushort)0x38),
+                ((ushort)0x8000, (ushort)0x1D)
+            ],
+            nativeSession.KeyboardEvents);
+    }
+
+    [Fact]
+    public void Status_LeavingConnected_ClearsKeyboardGrab()
+    {
+        var session = new RdpSessionViewModel(CreateConnection("Grab Status Test"), RdpSessionStatus.Connected)
+        {
+            IsKeyboardGrabbed = true
+        };
+
+        session.SetTestStatus(RdpSessionStatus.Disconnected);
+
+        Assert.False(session.IsKeyboardGrabbed);
+    }
+
+    [Fact]
     public void SetLocalClipboardFiles_ActiveNativeSession_ForwardsFileList()
     {
         var session = new RdpSessionViewModel(CreateConnection("Files Test"), RdpSessionStatus.Connected);
@@ -582,6 +616,7 @@ public sealed class RdpSessionViewModelTests
         public int FreeCallCount { get; private set; }
         public List<(int Width, int Height, uint DpiScalePercent)> ResolutionUpdates { get; } = [];
         public List<(ushort Flags, ushort X, ushort Y)> MouseEvents { get; } = [];
+        public List<(ushort Flags, ushort Code)> KeyboardEvents { get; } = [];
         public List<string> LocalClipboardFiles { get; } = [];
         public int RequestFullFrameCallCount { get; private set; }
 
@@ -607,6 +642,7 @@ public sealed class RdpSessionViewModelTests
 
         public void SendKeyboardEvent(ushort flags, ushort code)
         {
+            KeyboardEvents.Add((flags, code));
         }
 
         public void SetLocalClipboardText(string? text)

--- a/RDPilot.Client.Tests/RdpViewportPresenterKeyboardGrabTests.cs
+++ b/RDPilot.Client.Tests/RdpViewportPresenterKeyboardGrabTests.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Input;
+using RDPilot.Client;
+using RDPilot.Client.Models;
+using RDPilot.Client.Services;
+using RDPilot.Client.ViewModels;
+using RDPilot.Client.Views;
+using Xunit;
+
+namespace RDPilot.Client.Tests;
+
+/// <summary>
+/// Covers the grabbed-keyboard input path. The presenter takes all of its dependencies as
+/// delegates, so this needs no headless Avalonia session.
+/// </summary>
+[SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "xUnit test names use underscores for readability.")]
+public sealed class RdpViewportPresenterKeyboardGrabTests
+{
+    [Fact]
+    public void HandleGrabbedKey_ForwardsScancodeWithExtendedAndReleaseFlags()
+    {
+        var (presenter, keyboardEvents, _) = CreatePresenter();
+
+        presenter.HandleGrabbedKey(0x5B, extended: true, isUp: false);
+        presenter.HandleGrabbedKey(0x5B, extended: true, isUp: true);
+        presenter.HandleGrabbedKey(0x0F, extended: false, isUp: false);
+
+        Assert.Equal(
+            [
+                ((ushort)0x0100, (ushort)0x5B),
+                ((ushort)0x8100, (ushort)0x5B),
+                ((ushort)0x0000, (ushort)0x0F)
+            ],
+            keyboardEvents);
+    }
+
+    [Fact]
+    public void ReleaseGrabbedKeys_ReleasesOnlyKeysStillHeld()
+    {
+        var (presenter, keyboardEvents, _) = CreatePresenter();
+        presenter.HandleGrabbedKey(0x1D, extended: false, isUp: false);
+        presenter.HandleGrabbedKey(0x38, extended: false, isUp: false);
+        presenter.HandleGrabbedKey(0x38, extended: false, isUp: true);
+        keyboardEvents.Clear();
+
+        presenter.ReleaseGrabbedKeys();
+
+        Assert.Equal(((ushort)0x8000, (ushort)0x1D), Assert.Single(keyboardEvents));
+    }
+
+    [Fact]
+    public void ReleaseGrabbedKeys_IsIdempotent()
+    {
+        var (presenter, keyboardEvents, _) = CreatePresenter();
+        presenter.HandleGrabbedKey(0x1D, extended: false, isUp: false);
+        presenter.ReleaseGrabbedKeys();
+        keyboardEvents.Clear();
+
+        presenter.ReleaseGrabbedKeys();
+
+        Assert.Empty(keyboardEvents);
+    }
+
+    [Fact]
+    public void SetKeyboardGrabActive_EngagingReleasesKeysHeldOnTheAvaloniaPath()
+    {
+        var (presenter, keyboardEvents, rdpImage) = CreatePresenter();
+        Assert.True(presenter.HandleKeyDown(rdpImage, rdpImage, Key.LeftCtrl));
+        keyboardEvents.Clear();
+
+        presenter.SetKeyboardGrabActive(true);
+
+        Assert.Equal(((ushort)0x8000, (ushort)0x1D), Assert.Single(keyboardEvents));
+    }
+
+    [Fact]
+    public void SetKeyboardGrabActive_DisengagingReleasesGrabbedKeys()
+    {
+        var (presenter, keyboardEvents, _) = CreatePresenter();
+        presenter.SetKeyboardGrabActive(true);
+        presenter.HandleGrabbedKey(0x38, extended: false, isUp: false);
+        keyboardEvents.Clear();
+
+        presenter.SetKeyboardGrabActive(false);
+
+        Assert.Equal(((ushort)0x8000, (ushort)0x38), Assert.Single(keyboardEvents));
+    }
+
+    [Fact]
+    public void HandleKeyDown_WhileGrabbed_IsIgnoredSoKeysAreNeverSentTwice()
+    {
+        var (presenter, keyboardEvents, rdpImage) = CreatePresenter();
+        presenter.SetKeyboardGrabActive(true);
+
+        var handled = presenter.HandleKeyDown(rdpImage, rdpImage, Key.A);
+
+        Assert.False(handled);
+        Assert.Empty(keyboardEvents);
+    }
+
+    [Fact]
+    public void HandleGrabbedKey_ZeroScancode_IsIgnored()
+    {
+        var (presenter, keyboardEvents, _) = CreatePresenter();
+
+        Assert.False(presenter.HandleGrabbedKey(0, extended: false, isUp: false));
+        Assert.Empty(keyboardEvents);
+    }
+
+    private static (RdpViewportPresenter Presenter, List<(ushort Flags, ushort Code)> KeyboardEvents, object RdpImage) CreatePresenter()
+    {
+        var connection = new SavedConnection
+        {
+            Name = "Grab Test",
+            Host = "grab-test.example.local",
+            Username = "user"
+        };
+
+        var session = new RdpSessionViewModel(connection, RdpSessionStatus.Connected);
+        var nativeSession = new RecordingNativeSession(new IntPtr(0xBEEF));
+        SetField(session, "_nativeSession", nativeSession);
+        SetField(session, "_handle", nativeSession.Handle);
+
+        var vm = new MainWindowViewModel(new ConnectionStore(new FakeSecretStore()), new NoSessionFactory())
+        {
+            SelectedSession = session
+        };
+
+        var presenter = new RdpViewportPresenter(
+            () => vm,
+            () => null,
+            _ => [],
+            () => new Size(1280, 720),
+            () => { },
+            _ => null,
+            new ViewportResolutionService(),
+            new ClipboardSyncService(),
+            new ViewportResolutionUpdateScheduler(),
+            new PointerMoveScheduler());
+
+        return (presenter, nativeSession.KeyboardEvents, new object());
+    }
+
+    private static void SetField(object target, string fieldName, object? value)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field.SetValue(target, value);
+    }
+
+    private sealed class RecordingNativeSession(IntPtr handle) : INativeRdpSession
+    {
+        public IntPtr Handle { get; } = handle;
+        public List<(ushort Flags, ushort Code)> KeyboardEvents { get; } = [];
+
+        public void SendKeyboardEvent(ushort flags, ushort code) => KeyboardEvents.Add((flags, code));
+
+        public void Disconnect() { }
+        public void Free() { }
+        public void UpdateResolution(int width, int height, uint dpiScalePercent) { }
+        public void SendMouseEvent(ushort flags, ushort x, ushort y) { }
+        public void SetLocalClipboardText(string? text) { }
+        public void SetLocalClipboardFiles(string[] filePaths) { }
+        public void SetLocalClipboardBitmap(IntPtr bitmapData, nint bitmapDataSize, uint width, uint height) { }
+        public void RequestFullFrame() { }
+
+        public bool Present(
+            IntPtr dest,
+            int destStride,
+            int destWidth,
+            int destHeight,
+            out int dirtyX,
+            out int dirtyY,
+            out int dirtyWidth,
+            out int dirtyHeight,
+            out int fbWidth,
+            out int fbHeight)
+        {
+            dirtyX = dirtyY = dirtyWidth = dirtyHeight = fbWidth = fbHeight = 0;
+            return false;
+        }
+    }
+
+    private sealed class NoSessionFactory : IRdpSessionFactory
+    {
+        public RdpSessionViewModel Create(
+            SavedConnection connection,
+            string password,
+            string gatewayPassword,
+            int width,
+            int height,
+            double renderScaling,
+            int colorDepth,
+            bool compression,
+            bool fontSmoothing,
+            bool bitmapCache,
+            bool desktopWallpaper,
+            bool themes,
+            bool menuAnimations,
+            bool fullWindowDrag,
+            RdpConnectionType connectionType,
+            Action<RdpSessionViewModel, string> remoteClipboardTextReceived,
+            Action<RdpSessionViewModel, string[]> remoteClipboardFilesReceived)
+        {
+            throw new NotSupportedException("Sessions are created directly in these tests.");
+        }
+    }
+
+    private sealed class FakeSecretStore : ISecretStore
+    {
+        public string Description => "Fake";
+
+        public Task<string?> GetSecretAsync(string key) => Task.FromResult<string?>(null);
+        public Task SetSecretAsync(string key, string secret) => Task.CompletedTask;
+        public Task DeleteSecretAsync(string key) => Task.CompletedTask;
+    }
+}

--- a/RDPilot.Client/App.axaml
+++ b/RDPilot.Client/App.axaml
@@ -114,6 +114,13 @@
             <Setter Property="MinHeight" Value="28"/>
             <Setter Property="Padding" Value="0"/>
         </Style>
+        <Style Selector="Button.KeyboardGrabActive">
+            <Setter Property="Background" Value="{DynamicResource SystemAccentColorLight1}"/>
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+        <Style Selector="Button.KeyboardGrabActive:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
+        </Style>
         <Style Selector="Border.FullscreenSessionToolbar">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="Opacity" Value="0.96"/>

--- a/RDPilot.Client/Services/IKeyboardGrab.cs
+++ b/RDPilot.Client/Services/IKeyboardGrab.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace RDPilot.Client.Services;
+
+internal sealed class GrabbedKeyEventArgs : EventArgs
+{
+    public GrabbedKeyEventArgs(ushort scancode, bool extended, bool isUp)
+    {
+        Scancode = scancode;
+        Extended = extended;
+        IsUp = isUp;
+    }
+
+    public ushort Scancode { get; }
+    public bool Extended { get; }
+    public bool IsUp { get; }
+}
+
+/// <summary>
+/// Routes the whole physical keyboard to the active RDP session, preventing the local
+/// desktop from acting on shell chords such as the Windows key, Alt+Tab and Ctrl+Esc.
+/// </summary>
+internal interface IKeyboardGrab : IDisposable
+{
+    /// <summary>False when the current platform has no grab implementation.</summary>
+    bool IsSupported { get; }
+
+    /// <summary>Explains why grabbing is unavailable. Null when <see cref="IsSupported"/> is true.</summary>
+    string? UnsupportedReason { get; }
+
+    bool IsEngaged { get; }
+
+    /// <summary>Raised for every intercepted key while engaged. The key is not delivered locally.</summary>
+    event EventHandler<GrabbedKeyEventArgs>? KeyIntercepted;
+
+    /// <summary>Associates the grab with the host window, used to scope interception to the foreground window.</summary>
+    void Attach(IntPtr windowHandle);
+
+    void SetEngaged(bool engaged);
+}
+
+internal static class KeyboardGrab
+{
+    public static IKeyboardGrab CreateDefault()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return new WindowsKeyboardGrab();
+        }
+
+        return new NullKeyboardGrab();
+    }
+}

--- a/RDPilot.Client/Services/KeyboardGrabScanCodeMapper.cs
+++ b/RDPilot.Client/Services/KeyboardGrabScanCodeMapper.cs
@@ -1,0 +1,53 @@
+namespace RDPilot.Client.Services;
+
+/// <summary>
+/// Decodes a Windows low-level keyboard hook event into the raw RDP scancode form.
+/// Pure logic so it can be tested without a hook or an Avalonia session.
+/// </summary>
+internal static class KeyboardGrabScanCodeMapper
+{
+    private const uint LowLevelKeyExtended = 0x01;
+    private const uint LowLevelKeyUp = 0x80;
+
+    private const uint VirtualKeyPause = 0x13;
+    private const uint VirtualKeySnapshot = 0x2C;
+    private const uint VirtualKeyNumLock = 0x90;
+
+    private const ushort ScanCodeSnapshot = 0x37;
+    private const ushort ScanCodePause = 0x45;
+    private const ushort ScanCodeNumLock = 0x45;
+
+    public static bool TryMapHookEvent(
+        uint vkCode,
+        uint scanCode,
+        uint flags,
+        out ushort scancode,
+        out bool extended,
+        out bool isUp)
+    {
+        isUp = (flags & LowLevelKeyUp) != 0;
+        extended = (flags & LowLevelKeyExtended) != 0;
+        scancode = (ushort)(scanCode & 0xFF);
+
+        switch (vkCode)
+        {
+            case VirtualKeySnapshot:
+                // PrintScreen reports an unreliable scancode; the wire form is extended 0x37.
+                scancode = ScanCodeSnapshot;
+                extended = true;
+                break;
+            case VirtualKeyPause:
+                // Pause/Break needs the EXTENDED1 (0xE1) prefix, which the native input queue
+                // cannot express. Send the bare scancode; Break is not distinguishable.
+                scancode = ScanCodePause;
+                extended = false;
+                break;
+            case VirtualKeyNumLock:
+                scancode = ScanCodeNumLock;
+                extended = false;
+                break;
+        }
+
+        return scancode != 0;
+    }
+}

--- a/RDPilot.Client/Services/NullKeyboardGrab.cs
+++ b/RDPilot.Client/Services/NullKeyboardGrab.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace RDPilot.Client.Services;
+
+/// <summary>
+/// Grab implementation for platforms with no keyboard capture support.
+/// Wayland forbids client keyboard grabs outright, and the X11 XGrabKeyboard path
+/// is not implemented yet, so Linux falls back to this no-op.
+/// </summary>
+internal sealed class NullKeyboardGrab : IKeyboardGrab
+{
+    public bool IsSupported => false;
+
+    public string? UnsupportedReason => "Keyboard grab is currently available on Windows only.";
+
+    public bool IsEngaged => false;
+
+    public event EventHandler<GrabbedKeyEventArgs>? KeyIntercepted
+    {
+        add { }
+        remove { }
+    }
+
+    public void Attach(IntPtr windowHandle)
+    {
+    }
+
+    public void SetEngaged(bool engaged)
+    {
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/RDPilot.Client/Services/WindowsKeyboardGrab.cs
+++ b/RDPilot.Client/Services/WindowsKeyboardGrab.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace RDPilot.Client.Services;
+
+/// <summary>
+/// Captures the physical keyboard with a WH_KEYBOARD_LL hook, the same mechanism mstsc uses.
+/// While engaged the hook is the sole keyboard source: every key is suppressed locally and
+/// raised through <see cref="KeyIntercepted"/> instead, so the local shell never sees the
+/// Windows key, Alt+Tab or Ctrl+Esc.
+/// </summary>
+/// <remarks>
+/// The hook callback runs on the thread that installed it - the Avalonia UI thread, which
+/// already pumps a Win32 message loop. It must stay fast, lock-free and log-free: exceeding
+/// LowLevelHooksTimeout (~300 ms) makes Windows silently drop the hook.
+/// </remarks>
+[SupportedOSPlatform("windows")]
+internal sealed class WindowsKeyboardGrab : IKeyboardGrab
+{
+    private const int WhKeyboardLowLevel = 13;
+    private const int HcAction = 0;
+    private static readonly IntPtr SuppressKey = new(1);
+
+    private readonly LowLevelKeyboardProc _callback;
+    private IntPtr _hookHandle;
+    private IntPtr _windowHandle;
+    private bool _engaged;
+    private bool _disposed;
+
+    public WindowsKeyboardGrab()
+    {
+        // Held in a field so the delegate is not collected while the hook is installed.
+        _callback = OnKeyboardEvent;
+    }
+
+    public bool IsSupported => true;
+
+    public string? UnsupportedReason => null;
+
+    public bool IsEngaged => _engaged;
+
+    public event EventHandler<GrabbedKeyEventArgs>? KeyIntercepted;
+
+    public void Attach(IntPtr windowHandle)
+    {
+        _windowHandle = windowHandle;
+    }
+
+    public void SetEngaged(bool engaged)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _engaged = engaged;
+
+        if (!engaged)
+        {
+            UninstallHook();
+            return;
+        }
+
+        // Idempotent, and re-arms after Windows drops a hook that overran its timeout.
+        InstallHook();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _engaged = false;
+        UninstallHook();
+    }
+
+    private void InstallHook()
+    {
+        if (_hookHandle != IntPtr.Zero)
+        {
+            return;
+        }
+
+        var moduleHandle = GetModuleHandle(null);
+        _hookHandle = SetWindowsHookEx(WhKeyboardLowLevel, _callback, moduleHandle, 0);
+        if (_hookHandle == IntPtr.Zero)
+        {
+            Console.WriteLine($"[KEYGRAB] SetWindowsHookEx failed (error {Marshal.GetLastWin32Error()}).");
+        }
+    }
+
+    private void UninstallHook()
+    {
+        if (_hookHandle == IntPtr.Zero)
+        {
+            return;
+        }
+
+        UnhookWindowsHookEx(_hookHandle);
+        _hookHandle = IntPtr.Zero;
+    }
+
+    private IntPtr OnKeyboardEvent(int nCode, IntPtr wParam, IntPtr lParam)
+    {
+        try
+        {
+            if (nCode != HcAction || !_engaged || GetForegroundWindow() != _windowHandle)
+            {
+                return CallNextHookEx(IntPtr.Zero, nCode, wParam, lParam);
+            }
+
+            // KBDLLHOOKSTRUCT: vkCode, scanCode, flags, time, dwExtraInfo.
+            var virtualKeyCode = (uint)Marshal.ReadInt32(lParam, 0);
+            var scanCode = (uint)Marshal.ReadInt32(lParam, 4);
+            var hookFlags = (uint)Marshal.ReadInt32(lParam, 8);
+
+            if (!KeyboardGrabScanCodeMapper.TryMapHookEvent(
+                    virtualKeyCode,
+                    scanCode,
+                    hookFlags,
+                    out var scancode,
+                    out var extended,
+                    out var isUp))
+            {
+                return CallNextHookEx(IntPtr.Zero, nCode, wParam, lParam);
+            }
+
+            KeyIntercepted?.Invoke(this, new GrabbedKeyEventArgs(scancode, extended, isUp));
+            return SuppressKey;
+        }
+        catch
+        {
+            // An exception escaping a hook callback tears down the process; always fall through.
+            return CallNextHookEx(IntPtr.Zero, nCode, wParam, lParam);
+        }
+    }
+
+    private delegate IntPtr LowLevelKeyboardProc(int nCode, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr SetWindowsHookEx(int idHook, LowLevelKeyboardProc lpfn, IntPtr hMod, uint dwThreadId);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool UnhookWindowsHookEx(IntPtr hhk);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr GetModuleHandle(string? lpModuleName);
+}

--- a/RDPilot.Client/ViewModels/MainWindowViewModel.cs
+++ b/RDPilot.Client/ViewModels/MainWindowViewModel.cs
@@ -20,6 +20,19 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
     [ObservableProperty] private bool _selectedSessionCanReconnect;
     [ObservableProperty] private ShellPanel _activeShellPanel;
 
+    /// <summary>
+    /// Mirrors the selected session's grab state so the toolbar can bind to it. The view layer
+    /// owns the actual platform grab and watches this property.
+    /// </summary>
+    [ObservableProperty] private bool _isKeyboardGrabActive;
+
+    /// <summary>
+    /// Set by the view once it knows which grab implementation the platform provides.
+    /// Defaults to unsupported so headless tests never assume a grab exists.
+    /// </summary>
+    [ObservableProperty] private bool _isKeyboardGrabSupported;
+    [ObservableProperty] private string _keyboardGrabTooltip = "Keyboard grab is unavailable.";
+
     private readonly ConnectionStore _connectionStore;
     private readonly AppSettingsStore _settingsStore;
     private readonly IRdpSessionFactory _sessionFactory;
@@ -222,6 +235,12 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
 
     partial void OnSelectedSessionChanged(RdpSessionViewModel? oldValue, RdpSessionViewModel? newValue)
     {
+        if (oldValue != null)
+        {
+            // Grab never follows a tab switch; the user re-arms it explicitly per session.
+            oldValue.IsKeyboardGrabbed = false;
+        }
+
         oldValue?.SuspendPresentation();
         newValue?.ResumePresentation();
         UpdateSelectedSessionState();
@@ -265,6 +284,34 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
         SelectedSession = session;
         ActiveShellPanel = ShellPanel.None;
         StatusMessage = $"Connecting to {connection.Name}...";
+    }
+
+    [RelayCommand]
+    private void ToggleKeyboardGrab()
+    {
+        if (!IsKeyboardGrabSupported || SelectedSession is not { IsConnected: true } session)
+        {
+            return;
+        }
+
+        session.IsKeyboardGrabbed = !session.IsKeyboardGrabbed;
+    }
+
+    [RelayCommand]
+    private void SendCtrlAltDel()
+    {
+        SelectedSession?.SendCtrlAltDel();
+    }
+
+    /// <summary>Called by the view when the platform grab releases outside of a user toggle.</summary>
+    public void ReleaseKeyboardGrab()
+    {
+        if (SelectedSession != null)
+        {
+            SelectedSession.IsKeyboardGrabbed = false;
+        }
+
+        IsKeyboardGrabActive = false;
     }
 
     [RelayCommand]
@@ -475,7 +522,7 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
 
     private void OnSessionPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName is nameof(RdpSessionViewModel.Status) or nameof(RdpSessionViewModel.StatusText) or nameof(RdpSessionViewModel.LastError) or nameof(RdpSessionViewModel.ErrorText) or nameof(RdpSessionViewModel.IsConnected) or nameof(RdpSessionViewModel.CanDisconnect) or nameof(RdpSessionViewModel.CanReconnect)
+        if (e.PropertyName is nameof(RdpSessionViewModel.Status) or nameof(RdpSessionViewModel.StatusText) or nameof(RdpSessionViewModel.LastError) or nameof(RdpSessionViewModel.ErrorText) or nameof(RdpSessionViewModel.IsConnected) or nameof(RdpSessionViewModel.CanDisconnect) or nameof(RdpSessionViewModel.CanReconnect) or nameof(RdpSessionViewModel.IsKeyboardGrabbed)
             && ReferenceEquals(sender, SelectedSession))
         {
             UpdateSelectedSessionState();
@@ -488,6 +535,7 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
         IsConnected = SelectedSession?.IsConnected == true;
         SelectedSessionCanDisconnect = SelectedSession?.CanDisconnect == true;
         SelectedSessionCanReconnect = SelectedSession?.CanReconnect == true;
+        IsKeyboardGrabActive = SelectedSession?.IsKeyboardGrabbed == true;
         DisconnectSessionCommand.NotifyCanExecuteChanged();
         ReconnectSessionCommand.NotifyCanExecuteChanged();
         CloseSessionCommand.NotifyCanExecuteChanged();

--- a/RDPilot.Client/ViewModels/RdpSessionViewModel.cs
+++ b/RDPilot.Client/ViewModels/RdpSessionViewModel.cs
@@ -38,6 +38,12 @@ public partial class RdpSessionViewModel : ViewModelBase, IDisposable
     [ObservableProperty] private RdpSessionStatus _status = RdpSessionStatus.Connecting;
     [ObservableProperty] private RdpSessionError? _lastError;
 
+    /// <summary>
+    /// Transient per-session keyboard grab state. Deliberately not persisted: every connect
+    /// starts ungrabbed.
+    /// </summary>
+    [ObservableProperty] private bool _isKeyboardGrabbed;
+
     private readonly NativeWrapper.FrameCallback _frameCallback;
     private readonly NativeWrapper.ClipboardTextCallback _clipboardCallback;
     private readonly NativeWrapper.ClipboardFilesCallback _clipboardFilesCallback;
@@ -229,6 +235,11 @@ public partial class RdpSessionViewModel : ViewModelBase, IDisposable
         OnPropertyChanged(nameof(IsDisconnected));
         OnPropertyChanged(nameof(CanDisconnect));
         OnPropertyChanged(nameof(CanReconnect));
+
+        if (value != RdpSessionStatus.Connected)
+        {
+            IsKeyboardGrabbed = false;
+        }
     }
 
     partial void OnLastErrorChanged(RdpSessionError? value)
@@ -306,6 +317,26 @@ public partial class RdpSessionViewModel : ViewModelBase, IDisposable
         if (!TryGetActiveSession(out var nativeSession)) return;
         _framePresenter.MarkInputSent();
         nativeSession.SendKeyboardEvent(flags, code);
+    }
+
+    /// <summary>
+    /// Sends Ctrl+Alt+Del to the remote host. The secure attention sequence can never be
+    /// intercepted locally, so this explicit action is the only way to deliver it.
+    /// </summary>
+    public void SendCtrlAltDel()
+    {
+        const ushort leftCtrl = 0x1D;
+        const ushort leftAlt = 0x38;
+        const ushort delete = 0x53;
+        const ushort release = 0x8000;
+        const ushort extended = 0x0100;
+
+        SendKeyboardEvent(0, leftCtrl);
+        SendKeyboardEvent(0, leftAlt);
+        SendKeyboardEvent(extended, delete);
+        SendKeyboardEvent(release | extended, delete);
+        SendKeyboardEvent(release, leftAlt);
+        SendKeyboardEvent(release, leftCtrl);
     }
 
     public void SetLocalClipboardText(string text)

--- a/RDPilot.Client/Views/MainWindow.axaml.cs
+++ b/RDPilot.Client/Views/MainWindow.axaml.cs
@@ -5,6 +5,8 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
+using RDPilot.Client.Services;
+using RDPilot.Client.ViewModels;
 
 namespace RDPilot.Client.Views;
 
@@ -13,6 +15,8 @@ public partial class MainWindow : Window
     private readonly SessionTabsView _sessionToolbar;
     private readonly DispatcherTimer _toolbarHideTimer;
     private readonly HashSet<Key> _locallyHandledFullscreenKeys = [];
+    private readonly IKeyboardGrab _keyboardGrab = KeyboardGrab.CreateDefault();
+    private MainWindowViewModel? _subscribedViewModel;
     private WindowState _windowStateBeforeFullscreen = WindowState.Normal;
     private WindowState _lastNonFullscreenWindowState = WindowState.Normal;
     private bool _isFullscreen;
@@ -36,6 +40,10 @@ public partial class MainWindow : Window
         AddHandler(InputElement.KeyUpEvent, OnWindowKeyUp, RoutingStrategies.Tunnel, true);
         PropertyChanged += OnWindowPropertyChanged;
         Deactivated += OnWindowDeactivated;
+        Activated += OnWindowActivated;
+        DataContextChanged += OnDataContextChanged;
+        _keyboardGrab.KeyIntercepted += OnGrabbedKeyIntercepted;
+        Opened += OnWindowOpened;
 
         Closed += (_, _) =>
         {
@@ -43,11 +51,93 @@ public partial class MainWindow : Window
             _toolbarHideTimer.Tick -= OnToolbarHideTimerTick;
             PropertyChanged -= OnWindowPropertyChanged;
             Deactivated -= OnWindowDeactivated;
+            Activated -= OnWindowActivated;
+            DataContextChanged -= OnDataContextChanged;
+            Opened -= OnWindowOpened;
+            _keyboardGrab.KeyIntercepted -= OnGrabbedKeyIntercepted;
+            SubscribeViewModel(null);
+            _keyboardGrab.Dispose();
             if (DataContext is IDisposable disposable)
             {
                 disposable.Dispose();
             }
         };
+    }
+
+    private void OnWindowOpened(object? sender, EventArgs e)
+    {
+        var handle = TryGetPlatformHandle()?.Handle;
+        if (handle.HasValue)
+        {
+            _keyboardGrab.Attach(handle.Value);
+        }
+
+        PublishKeyboardGrabAvailability();
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        SubscribeViewModel(DataContext as MainWindowViewModel);
+        PublishKeyboardGrabAvailability();
+    }
+
+    private void SubscribeViewModel(MainWindowViewModel? viewModel)
+    {
+        if (ReferenceEquals(_subscribedViewModel, viewModel))
+        {
+            return;
+        }
+
+        if (_subscribedViewModel != null)
+        {
+            _subscribedViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+        }
+
+        _subscribedViewModel = viewModel;
+
+        if (_subscribedViewModel != null)
+        {
+            _subscribedViewModel.PropertyChanged += OnViewModelPropertyChanged;
+        }
+    }
+
+    private void PublishKeyboardGrabAvailability()
+    {
+        if (_subscribedViewModel == null)
+        {
+            return;
+        }
+
+        _subscribedViewModel.IsKeyboardGrabSupported = _keyboardGrab.IsSupported;
+        _subscribedViewModel.KeyboardGrabTooltip = _keyboardGrab.IsSupported
+            ? "Grab keyboard so Win, Alt+Tab and Ctrl+Esc go to the remote session"
+            : _keyboardGrab.UnsupportedReason ?? "Keyboard grab is unavailable.";
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(MainWindowViewModel.IsKeyboardGrabActive))
+        {
+            ApplyKeyboardGrabState();
+        }
+    }
+
+    private void ApplyKeyboardGrabState()
+    {
+        var engaged = _subscribedViewModel?.IsKeyboardGrabActive == true && _keyboardGrab.IsSupported;
+        _keyboardGrab.SetEngaged(engaged);
+        RdpViewport.SetKeyboardGrabActive(engaged);
+    }
+
+    private void OnGrabbedKeyIntercepted(object? sender, GrabbedKeyEventArgs e)
+    {
+        RdpViewport.HandleGrabbedKey(e.Scancode, e.Extended, e.IsUp);
+    }
+
+    private void OnWindowActivated(object? sender, EventArgs e)
+    {
+        // Re-arms the hook if Windows dropped it after a UI-thread stall.
+        ApplyKeyboardGrabState();
     }
 
     private void OnFullscreenToggleRequested(object? sender, EventArgs e)
@@ -86,6 +176,12 @@ public partial class MainWindow : Window
     private void OnWindowDeactivated(object? sender, EventArgs e)
     {
         _locallyHandledFullscreenKeys.Clear();
+
+        // The only escape route from a grab, since there is no release hotkey: clicking another
+        // window deactivates us and hands the keyboard back to the local desktop.
+        _subscribedViewModel?.ReleaseKeyboardGrab();
+        _keyboardGrab.SetEngaged(false);
+        RdpViewport.SetKeyboardGrabActive(false);
     }
 
     private void SetFullscreen(bool isFullscreen)

--- a/RDPilot.Client/Views/RdpKeyboardInputMapper.cs
+++ b/RDPilot.Client/Views/RdpKeyboardInputMapper.cs
@@ -7,6 +7,9 @@ internal static class RdpKeyboardInputMapper
     private const ushort KeyboardFlagsRelease = 0x8000;
     private const ushort KeyboardFlagsExtended = 0x0100;
 
+    /// <summary>Marks a scancode in this table as an extended (0xE0-prefixed) key.</summary>
+    public const ushort ExtendedScancodeBit = 0x100;
+
     public static bool TryMapKey(Key key, out ushort scancode)
     {
         scancode = key switch
@@ -120,7 +123,7 @@ internal static class RdpKeyboardInputMapper
     {
         ushort flags = isRelease ? KeyboardFlagsRelease : (ushort)0;
         normalizedScancode = scancode;
-        if ((normalizedScancode & 0x100) != 0)
+        if ((normalizedScancode & ExtendedScancodeBit) != 0)
         {
             flags |= KeyboardFlagsExtended;
             normalizedScancode &= 0xFF;

--- a/RDPilot.Client/Views/RdpViewportPresenter.cs
+++ b/RDPilot.Client/Views/RdpViewportPresenter.cs
@@ -24,7 +24,9 @@ internal sealed class RdpViewportPresenter
     private readonly PointerMoveScheduler _pointerMoveScheduler;
     private readonly ClipboardSyncService _clipboardSyncService;
     private readonly HashSet<Key> _pressedRdpKeys = new();
+    private readonly HashSet<ushort> _pressedGrabbedScancodes = new();
     private bool _rdpKeyboardActive;
+    private bool _keyboardGrabActive;
     private double _lastObservedScale = 1.0;
 
     public RdpViewportPresenter(
@@ -358,8 +360,79 @@ internal sealed class RdpViewportPresenter
         _rdpKeyboardActive = false;
     }
 
+    /// <summary>
+    /// Engages or releases keyboard grab. While grabbed the platform hook is the sole keyboard
+    /// source, so the Avalonia path is shut off and each path flushes its own held keys on the
+    /// transition to avoid stuck modifiers on the remote host.
+    /// </summary>
+    public void SetKeyboardGrabActive(bool active)
+    {
+        if (_keyboardGrabActive == active)
+        {
+            return;
+        }
+
+        if (active)
+        {
+            ReleasePressedRdpKeys();
+            _keyboardGrabActive = true;
+        }
+        else
+        {
+            _keyboardGrabActive = false;
+            ReleaseGrabbedKeys();
+        }
+    }
+
+    public bool HandleGrabbedKey(ushort scancode, bool extended, bool isUp)
+    {
+        var vm = _getViewModel();
+        if (vm == null || scancode == 0)
+        {
+            return false;
+        }
+
+        var trackedScancode = (ushort)(scancode | (extended ? RdpKeyboardInputMapper.ExtendedScancodeBit : 0));
+        var flags = RdpKeyboardInputMapper.BuildKeyFlags(trackedScancode, isUp, out var normalizedScancode);
+        vm.SendKeyboardEvent(flags, normalizedScancode);
+
+        if (isUp)
+        {
+            _pressedGrabbedScancodes.Remove(trackedScancode);
+        }
+        else
+        {
+            _pressedGrabbedScancodes.Add(trackedScancode);
+        }
+
+        return true;
+    }
+
+    public void ReleaseGrabbedKeys()
+    {
+        var vm = _getViewModel();
+        if (_pressedGrabbedScancodes.Count == 0 || vm == null)
+        {
+            _pressedGrabbedScancodes.Clear();
+            return;
+        }
+
+        foreach (var trackedScancode in _pressedGrabbedScancodes)
+        {
+            var flags = RdpKeyboardInputMapper.BuildKeyFlags(trackedScancode, isRelease: true, out var normalizedScancode);
+            vm.SendKeyboardEvent(flags, normalizedScancode);
+        }
+
+        _pressedGrabbedScancodes.Clear();
+    }
+
     private bool ShouldHandleKeyboardEvent(object? source, object rdpImage)
     {
+        if (_keyboardGrabActive)
+        {
+            return false;
+        }
+
         return ReferenceEquals(source, rdpImage) || _rdpKeyboardActive;
     }
 

--- a/RDPilot.Client/Views/RdpViewportView.axaml.cs
+++ b/RDPilot.Client/Views/RdpViewportView.axaml.cs
@@ -45,6 +45,16 @@ public partial class RdpViewportView : UserControl
         RdpImage.LostFocus += (_, _) => _presenter.ReleasePressedRdpKeys();
     }
 
+    internal void SetKeyboardGrabActive(bool active)
+    {
+        _presenter.SetKeyboardGrabActive(active);
+    }
+
+    internal void HandleGrabbedKey(ushort scancode, bool extended, bool isUp)
+    {
+        _presenter.HandleGrabbedKey(scancode, extended, isUp);
+    }
+
     private void OnDataContextChanged(object? sender, EventArgs e)
     {
         if (_subscribedViewModel != null)
@@ -90,6 +100,7 @@ public partial class RdpViewportView : UserControl
     {
         _clipboardPollTimer.Stop();
         _presenter.ReleasePressedRdpKeys();
+        _presenter.ReleaseGrabbedKeys();
         _presenter.CancelViewportResolutionUpdates();
 
         if (_hostWindow == null)
@@ -175,6 +186,7 @@ public partial class RdpViewportView : UserControl
     private void OnHostWindowDeactivated(object? sender, EventArgs e)
     {
         _presenter.ReleasePressedRdpKeys();
+        _presenter.ReleaseGrabbedKeys();
     }
 
     private void OnHostWindowLayoutUpdated(object? sender, EventArgs e)

--- a/RDPilot.Client/Views/SessionTabsView.axaml
+++ b/RDPilot.Client/Views/SessionTabsView.axaml
@@ -39,17 +39,43 @@
             </TabControl.ContentTemplate>
         </TabControl>
         <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6" HorizontalAlignment="Right" VerticalAlignment="Center">
-            <Button Classes="TopBarButton" MinWidth="84" Command="{Binding DisconnectSessionCommand}" CommandParameter="{Binding SelectedSession}" IsVisible="{Binding SelectedSessionCanDisconnect}">
-                <StackPanel Orientation="Horizontal" Spacing="6"><icons:FluentIcon Icon="PlugDisconnected" IconSize="Size16" FontSize="16"/><TextBlock Text="Disconnect"/></StackPanel>
+            <Button x:Name="SendCtrlAltDelButton"
+                    Classes="IconButton FullscreenToolbarButton"
+                    ToolTip.Tip="Send Ctrl+Alt+Del to the remote session"
+                    IsVisible="{Binding SelectedSessionCanDisconnect}"
+                    Command="{Binding SendCtrlAltDelCommand}">
+                <icons:FluentIcon Icon="LockClosedKey" IconSize="Size16" FontSize="16"/>
             </Button>
-            <Button Classes="TopBarButton" MinWidth="84" Command="{Binding ReconnectSessionCommand}" CommandParameter="{Binding SelectedSession}" IsVisible="{Binding SelectedSessionCanReconnect}">
-                <StackPanel Orientation="Horizontal" Spacing="6"><icons:FluentIcon Icon="ArrowClockwise" IconSize="Size16" FontSize="16"/><TextBlock Text="Reconnect"/></StackPanel>
+            <Button x:Name="KeyboardGrabToggleButton"
+                    Classes="IconButton FullscreenToolbarButton"
+                    Classes.KeyboardGrabActive="{Binding IsKeyboardGrabActive}"
+                    ToolTip.Tip="{Binding KeyboardGrabTooltip}"
+                    IsVisible="{Binding HasSelectedSession}"
+                    IsEnabled="{Binding IsKeyboardGrabSupported}"
+                    Command="{Binding ToggleKeyboardGrabCommand}">
+                <icons:FluentIcon Icon="Keyboard" IconSize="Size16" FontSize="16"/>
             </Button>
             <Button x:Name="FullscreenToggleButton"
                     Classes="IconButton FullscreenToolbarButton"
                     ToolTip.Tip="Enter fullscreen"
                     Click="OnFullscreenToggleClicked">
                 <icons:FluentIcon Icon="FullScreenMaximize" IconSize="Size16" FontSize="16"/>
+            </Button>
+            <Button x:Name="ReconnectSessionButton"
+                    Classes="IconButton FullscreenToolbarButton"
+                    ToolTip.Tip="Reconnect"
+                    IsVisible="{Binding SelectedSessionCanReconnect}"
+                    Command="{Binding ReconnectSessionCommand}"
+                    CommandParameter="{Binding SelectedSession}">
+                <icons:FluentIcon Icon="ArrowClockwise" IconSize="Size16" FontSize="16"/>
+            </Button>
+            <Button x:Name="DisconnectSessionButton"
+                    Classes="IconButton FullscreenToolbarButton"
+                    ToolTip.Tip="Disconnect"
+                    IsVisible="{Binding SelectedSessionCanDisconnect}"
+                    Command="{Binding DisconnectSessionCommand}"
+                    CommandParameter="{Binding SelectedSession}">
+                <icons:FluentIcon Icon="PlugDisconnected" IconSize="Size16" FontSize="16"/>
             </Button>
         </StackPanel>
     </Grid>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ RDPilot currently supports Windows and Linux.
 
 - Dynamic resolution when the client window changes size.
 - Low-latency keyboard and mouse input with mouse-move coalescing.
+- Keyboard grab (Windows only) so `Win`, `Alt+Tab`, `Ctrl+Esc` and other shell chords go to the remote session instead of the local desktop, plus a toolbar action to send `Ctrl+Alt+Del`.
 - Multiple simultaneous RDP sessions through tabs.
 - Saved connection profiles with passwords stored in the OS credential vault.
 - Text clipboard sync between local and remote sessions.
@@ -59,6 +60,14 @@ Linux is supported, but the package has not been published to the AUR yet.
 
 Each `Connect` action opens a separate tab. Switching tabs keeps background sessions connected and routes input, resize, and clipboard updates only to the active session.
 
+### Keyboard grab
+
+The keyboard button in the session toolbar routes the whole physical keyboard to the active session, so `Win`, `Alt+Tab`, `Ctrl+Esc` and `Alt+Esc` act on the remote desktop instead of the local one. While grabbed, RDPilot's own UI is not reachable by keyboard — that is what grabbing means. There is no release hotkey; click the toolbar button again, or click any other window, which releases the grab automatically.
+
+Grab is per-session and never persisted: every new connection starts ungrabbed, switching tabs releases it, and disconnecting releases it.
+
+`Ctrl+Alt+Del` cannot be intercepted by any application, so use the toolbar button beside the grab toggle to send it to the remote session. `Win+L` likewise always locks the local machine.
+
 ## Data Storage
 
 Saved connection metadata is stored per user:
@@ -75,6 +84,7 @@ Passwords are stored separately:
 
 ## Notes
 
+- Keyboard grab is **not available on Linux**; the toolbar button is shown disabled there. Wayland forbids clients from grabbing the keyboard (the sanctioned `zwp_keyboard_shortcuts_inhibit_manager_v1` protocol is not exposed by the current Avalonia Wayland backend), and the X11 `XGrabKeyboard` path is not implemented yet. Sending `Ctrl+Alt+Del` works on every platform.
 - Clipboard redirection is currently text-focused.
 - Audio playback and device redirection are disabled.
 - The default rendering mode is `gfx-gdi`.


### PR DESCRIPTION
Adds a toolbar toggle that routes the whole physical keyboard to the active session, so Win, Alt+Tab, Ctrl+Esc and Alt+Esc act on the remote desktop instead of the local shell.

Windows uses a WH_KEYBOARD_LL hook (Services/WindowsKeyboardGrab.cs). While engaged the hook is the sole keyboard source: it suppresses every key locally and raises scancodes decoded straight from KBDLLHOOKSTRUCT, bypassing the Avalonia Key mapping table entirely. The two input paths are mutually exclusive and each flushes its held keys on the transition so modifiers cannot stick on the remote host.

Grab is per-session and transient: it releases on disconnect, on tab switch, and on window deactivation, which is the only escape route since there is no release hotkey. Interception is scoped to the foreground window and the hook is only installed while engaged.

Linux has no implementation (NullKeyboardGrab); Wayland forbids client keyboard grabs and the X11 XGrabKeyboard path is not built yet, so the toggle renders disabled with an explanatory tooltip.

Also adds a Send Ctrl+Alt+Del toolbar action, since the secure attention sequence can never be intercepted, and makes the Disconnect/Reconnect buttons icon-only so they match the rest of the toolbar.

No native wrapper changes: everything reuses rdp_session_send_keyboard_event.